### PR TITLE
replace 'eth_chainId' with 'quai_chainId'

### DIFF
--- a/internal/core/providers/chainId.js
+++ b/internal/core/providers/chainId.js
@@ -12,7 +12,7 @@ class ProviderWrapperWithChainId extends wrapper_1.ProviderWrapper {
                 this._chainId = await this._getChainIdFromEthChainId();
             }
             catch {
-                // If eth_chainId fails we default to net_version
+                // If quai_chainId fails we default to net_version
                 this._chainId = await this._getChainIdFromEthNetVersion();
             }
         }
@@ -20,7 +20,7 @@ class ProviderWrapperWithChainId extends wrapper_1.ProviderWrapper {
     }
     async _getChainIdFromEthChainId() {
         const id = (await this._wrappedProvider.request({
-            method: "eth_chainId",
+            method: "quai_chainId",
         }));
         return (0, base_types_1.rpcQuantityToNumber)(id);
     }

--- a/internal/hardhat-network/provider/modules/eth.js
+++ b/internal/hardhat-network/provider/modules/eth.js
@@ -67,7 +67,7 @@ class EthModule {
                 return this._blockNumberAction(...this._blockNumberParams(params));
             case "eth_call":
                 return this._callAction(...this._callParams(params));
-            case "eth_chainId":
+            case "quai_chainId":
                 return this._chainIdAction(...this._chainIdParams(params));
             case "eth_coinbase":
                 return this._coinbaseAction(...this._coinbaseParams(params));
@@ -208,7 +208,7 @@ class EthModule {
         }
         return (0, base_types_1.bufferToRpcData)(returnData.value);
     }
-    // eth_chainId
+    // quai_chainId
     _chainIdParams(params) {
         return (0, validation_1.validateParams)(params);
     }

--- a/src/internal/core/providers/chainId.ts
+++ b/src/internal/core/providers/chainId.ts
@@ -13,7 +13,7 @@ export abstract class ProviderWrapperWithChainId extends ProviderWrapper {
       try {
         this._chainId = await this._getChainIdFromEthChainId();
       } catch {
-        // If eth_chainId fails we default to net_version
+        // If quai_chainId fails we default to net_version
         this._chainId = await this._getChainIdFromEthNetVersion();
       }
     }
@@ -23,7 +23,7 @@ export abstract class ProviderWrapperWithChainId extends ProviderWrapper {
 
   private async _getChainIdFromEthChainId(): Promise<number> {
     const id = (await this._wrappedProvider.request({
-      method: "eth_chainId",
+      method: "quai_chainId",
     })) as string;
 
     return rpcQuantityToNumber(id);

--- a/src/internal/hardhat-network/provider/modules/eth.ts
+++ b/src/internal/hardhat-network/provider/modules/eth.ts
@@ -121,7 +121,7 @@ export class EthModule {
       case "eth_call":
         return this._callAction(...this._callParams(params));
 
-      case "eth_chainId":
+      case "quai_chainId":
         return this._chainIdAction(...this._chainIdParams(params));
 
       case "eth_coinbase":
@@ -391,7 +391,7 @@ export class EthModule {
     return bufferToRpcData(returnData.value);
   }
 
-  // eth_chainId
+  // quai_chainId
 
   private _chainIdParams(params: any[]): [] {
     return validateParams(params);


### PR DESCRIPTION
This PR changes the RPC method name from `eth_chainId` to `quai_chainId` to support quai's name space.
